### PR TITLE
Modify the entry script

### DIFF
--- a/fabric/entry.sh
+++ b/fabric/entry.sh
@@ -9,21 +9,12 @@ if [ ! -f "install-fabric.sh" ]; then
     chmod +x install-fabric.sh
 fi
 
-directory="bin"
 
-# Check if the directory exists
-if [ ! -d "$directory" ]; then
-    # If it doesn't exist, create it
-    mkdir "$directory"
-fi
+# Install binaries
 
-# Move into the directory
-cd "$directory" || exit
+./install-fabric.sh "binary" "docker"
 
-# Install binaryies 
-$ROOTDIR/install-fabric.sh "binary" "docker"
-
-# Move back to the previous directory
-cd - || exit
+# # Move back to the previous directory
+# cd - || exit
 
 


### PR DESCRIPTION
This PR modifies the entry.sh script to fix the error in the installation of the script. There is a mixup of the bin directory when the script is called during installation