### PR TITLE
Create the java hyperledger sdk and configurations

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -85,6 +85,17 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-validation</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.hyperledger.fabric</groupId>
+			<artifactId>fabric-gateway</artifactId>
+			<version>1.4.0</version>
+		</dependency>
+		<dependency>
+			<groupId>io.grpc</groupId>
+			<artifactId>grpc-netty-shaded</artifactId>
+			<version>1.59.0</version>
+			<scope>runtime</scope>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/backend/src/main/java/com/firstacademy/firstblock/config/HyperledgerConfig.java
+++ b/backend/src/main/java/com/firstacademy/firstblock/config/HyperledgerConfig.java
@@ -1,0 +1,120 @@
+package com.firstacademy.firstblock.config;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonParser;
+
+import io.grpc.Channel;
+import io.grpc.Grpc;
+import io.grpc.ManagedChannel;
+import io.grpc.TlsChannelCredentials;
+import org.hyperledger.fabric.client.CommitException;
+import org.hyperledger.fabric.client.CommitStatusException;
+import org.hyperledger.fabric.client.Contract;
+import org.hyperledger.fabric.client.EndorseException;
+import org.hyperledger.fabric.client.Gateway;
+import org.hyperledger.fabric.client.Gateway.Builder;
+import org.hyperledger.fabric.client.GatewayException;
+import org.hyperledger.fabric.client.SubmitException;
+import org.hyperledger.fabric.client.identity.Identities;
+import org.hyperledger.fabric.client.identity.Identity;
+import org.hyperledger.fabric.client.identity.Signer;
+import org.hyperledger.fabric.client.identity.Signers;
+import org.hyperledger.fabric.client.identity.X509Identity;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.InvalidKeyException;
+import java.security.cert.CertificateException;
+import java.time.Instant;
+import java.util.concurrent.TimeUnit;
+
+
+@Configuration
+public class HyperledgerConfig {
+
+    @Autowired
+    private Environment environment;
+
+    private final String MSP_ID = environment.getProperty("hyperledger.fabric.org.msp");
+	private final String CHANNEL_NAME = environment.getProperty("hyperledger.fabric.org.channel");
+	private final String CHAINCODE_NAME = environment.getProperty("hyperledger.fabric.org.cc-name");
+
+    // Path to crypto materials.
+	private final Path CRYPTO_PATH = Paths.get("../../../../../../../../fabric/network/organizations/peerOrganizations/org1.example.com");
+    
+	// Path to user certificate.
+	private final Path CERT_PATH = CRYPTO_PATH.resolve(Paths.get("users/User1@org1.example.com/msp/signcerts/cert.pem"));
+	// Path to user private key directory.
+	private final Path KEY_DIR_PATH = CRYPTO_PATH.resolve(Paths.get("users/User1@org1.example.com/msp/keystore"));
+	// Path to peer tls certificate.
+	private final Path TLS_CERT_PATH = CRYPTO_PATH.resolve(Paths.get("peers/peer0.org1.example.com/tls/ca.crt"));
+
+    // Gateway peer end point.
+	private final String PEER_ENDPOINT = environment.getProperty("hyperledger.fabric.org.peer-endpoint");
+	private final String OVERRIDE_AUTH = environment.getProperty("hyperledger.fabric.org.override-auth");
+
+	private final Gson gson = new GsonBuilder().setPrettyPrinting().create();
+
+    @Bean
+    public Gateway configureFabric(final String[] args) throws Exception {
+		// The gRPC client connection should be shared by all Gateway connections to
+		// this endpoint.
+		var channel = newGrpcConnection();
+        
+
+        var builder = Gateway.newInstance().identity(newIdentity()).signer(newSigner()).connection(channel)
+				// Default timeouts for different gRPC calls
+				.evaluateOptions(options -> options.withDeadlineAfter(5, TimeUnit.SECONDS))
+				.endorseOptions(options -> options.withDeadlineAfter(15, TimeUnit.SECONDS))
+				.submitOptions(options -> options.withDeadlineAfter(5, TimeUnit.SECONDS))
+				.commitStatusOptions(options -> options.withDeadlineAfter(1, TimeUnit.MINUTES));
+
+     
+        return builder.connect();
+        
+	}
+
+    @Bean
+    public Contract createChannel(Gateway gateway) throws Exception {
+        var network  = gateway.getNetwork(CHANNEL_NAME);
+        return network.getContract(CHAINCODE_NAME);
+    }
+
+    private ManagedChannel newGrpcConnection() throws IOException {
+		var credentials = TlsChannelCredentials.newBuilder()
+				.trustManager(TLS_CERT_PATH.toFile())
+				.build();
+		return Grpc.newChannelBuilder(PEER_ENDPOINT, credentials)
+				.overrideAuthority(OVERRIDE_AUTH)
+				.build();
+	}
+
+	private Identity newIdentity() throws IOException, CertificateException {
+		var certReader = Files.newBufferedReader(CERT_PATH);
+		var certificate = Identities.readX509Certificate(certReader);
+
+		return new X509Identity(MSP_ID, certificate);
+	}
+
+	private Signer newSigner() throws IOException, InvalidKeyException {
+		var keyReader = Files.newBufferedReader(getPrivateKeyPath());
+		var privateKey = Identities.readPrivateKey(keyReader);
+
+		return Signers.newPrivateKeySigner(privateKey);
+	}
+
+	private Path getPrivateKeyPath() throws IOException {
+		try (var keyFiles = Files.list(KEY_DIR_PATH)) {
+			return keyFiles.findFirst().orElseThrow();
+		}
+	}
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -8,5 +8,9 @@ spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=${SHOW_SQL:false}
 logging.level.org.springframework.security=TRACE
 cors.allowed-origins=${ALLOWED_ORIGIN:http://localhost:4200}
-
+hyperledger.fabric.org.msp=${MSP_ID:Org1MSP}
+hyperledger.fabric.org.channel=${CHANNEL_NAME:mainchannel}
+hyperledger.fabric.org.cc-name=${CHAINCODE_NAME:bank-transactions}
+hyperledger.fabric.org.peer-endpoint=${PEER_ENDPOINT:localhost:7051}
+hyperledger.fabric.org.override-auth=${OVERRIDE_AUTH:peer0.org1.example.com}
 springfox.documentation.swagger-ui.base-url=/documentation


### PR DESCRIPTION
In this Pull Request:

- The hyper ledger fabric SDK for java dependencies was added to the pom file.
- A bean configuration(hyperledgerConfig.java) was created to interact with the Fabric blockchain network. It provides a simple API to submit transactions to a ledger or query the contents of a ledger with minimal code.